### PR TITLE
Real IP Passing To hlswatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV TZ=Europe/Berlin
 
 # install dependencies
 RUN apk --update --no-cache add git gcc musl-dev tzdata
-WORKDIR /go/src/github.com/faryon93/hlswatch
+WORKDIR /go/src/github.com/aminhusni/hlswatch
 ADD ./ ./
 
 # build the go binary
-RUN go get github.com/faryon93/hlswatch && \
+RUN go get github.com/aminhusni/hlswatch && \
     go build -v -o /tmp/hlswatch .
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /go/src/github.com/aminhusni/hlswatch
 ADD ./ ./
 
 # build the go binary
-RUN go get github.com/aminhusni/hlswatch && \
+RUN go env -w GOSUMDB=sum.golang.google.cn && \
+    go env -w GOPROXY=https://goproxy.cn && \
+    go get github.com/aminhusni/hlswatch && \
     go build -v -o /tmp/hlswatch .
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,60 +20,14 @@ ENV NGINX_VERSION="1.13.11"
 ENV BUILD_TOOLS="g++ make pcre-dev openssl-dev unzip"
 ENV RUNTIME_LIBS="openssl pcre"
 
-# download the sources
-ADD http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz /tmp
-ADD https://github.com/arut/nginx-rtmp-module/archive/master.zip /tmp/nginx-rtmp-master.zip
-
-# compile and install nginx
-RUN apk add --update $BUILD_TOOLS $RUNTIME_LIBS && \
-	cd /tmp && \
-	tar xzvf nginx-$NGINX_VERSION.tar.gz && \
-	unzip nginx-rtmp-master.zip && \
-	cd /tmp/nginx-$NGINX_VERSION && \
-	./configure --prefix=/usr \
-				--modules-path=/var/lib/nginx/modules \
-				--conf-path=/etc/nginx/nginx.conf \
-				--pid-path=/var/run/nginx.pid \
-				--lock-path=/var/run/nginx.lock \
-				--sbin-path=/usr/sbin/nginx \
-				--error-log-path=/var/log/nginx/error.log \
-				--http-log-path=/var/log/nginx/access.log \
-				--http-client-body-temp-path=/tmp/client_body_temp \
-				--http-proxy-temp-path=/tmp/proxy_temp \
-				--user=www \
-				--group=www \
-				--add-module=/tmp/nginx-rtmp-module-master \
-				--without-http_fastcgi_module \
-				--without-http_uwsgi_module \
-				--without-http_scgi_module \
-				--with-http_ssl_module  \ 
-				--with-http_v2_module && \
-	make -j5 && \
-	make install && \
-	rm -r /usr/html && \
-# remove build tools
-	rm -r /tmp/nginx-$NGINX_VERSION && \
-	rm -r /tmp/nginx-rtmp-module-master && \
-	rm /tmp/nginx-rtmp-master.zip && \
-	rm /tmp/nginx-$NGINX_VERSION.tar.gz && \
-	apk del $BUILD_TOOLS && \
-	rm -rf /var/cache/apk/*
-
 # setup users
 RUN adduser -D -u 1000 -g 'www' www
 
-# network configuration
-EXPOSE 1935
-EXPOSE 80
-EXPOSE 443
-
 # setup the rootfs
 ADD hlswatch.conf /etc/
-ADD nginx.conf /etc/nginx/nginx.conf
 ADD entry.sh /
 COPY --from=builder /tmp/hlswatch /usr/sbin/hlswatch
-RUN mkdir /tmp/hls && \
-    chmod 755 /entry.sh && \
+RUN chmod 755 /entry.sh && \
     chmod 755 /usr/sbin/hlswatch
 
 # start command

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 /usr/sbin/hlswatch &
-/usr/sbin/nginx -g "daemon off;"
+

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-/usr/sbin/hlswatch &
-
+/usr/sbin/hlswatch 

--- a/handler/hls.go
+++ b/handler/hls.go
@@ -27,6 +27,8 @@ import (
     "crypto/rand"
     "encoding/base64"
     "log"
+    "net"
+    "bytes"
 
     "github.com/faryon93/hlswatch/state"
 )
@@ -40,6 +42,84 @@ const (
     PLAYLIST_FILE_EXTENSION = "m3u8"
     TOKEN_URL_PARAMETER     = "token"
 )
+
+//ipRange - a structure that holds the start and end of a range of ip addresses
+type ipRange struct {
+    start net.IP
+    end net.IP
+}
+
+// inRange - check to see if a given ip address is within a range given
+func inRange(r ipRange, ipAddress net.IP) bool {
+    // strcmp type byte comparison
+    if bytes.Compare(ipAddress, r.start) >= 0 && bytes.Compare(ipAddress, r.end) < 0 {
+        return true
+    }
+    return false
+}
+
+var privateRanges = []ipRange{
+    ipRange{
+        start: net.ParseIP("10.0.0.0"),
+        end:   net.ParseIP("10.255.255.255"),
+    },
+    ipRange{
+        start: net.ParseIP("100.64.0.0"),
+        end:   net.ParseIP("100.127.255.255"),
+    },
+    ipRange{
+        start: net.ParseIP("172.16.0.0"),
+        end:   net.ParseIP("172.31.255.255"),
+    },
+    ipRange{
+        start: net.ParseIP("192.0.0.0"),
+        end:   net.ParseIP("192.0.0.255"),
+    },
+    ipRange{
+        start: net.ParseIP("192.168.0.0"),
+        end:   net.ParseIP("192.168.255.255"),
+    },
+    ipRange{
+        start: net.ParseIP("198.18.0.0"),
+        end:   net.ParseIP("198.19.255.255"),
+    },
+}
+
+
+// isPrivateSubnet - check to see if this ip is in a private subnet
+func isPrivateSubnet(ipAddress net.IP) bool {
+    // my use case is only concerned with ipv4 atm
+    if ipCheck := ipAddress.To4(); ipCheck != nil {
+        // iterate over all our ranges
+        for _, r := range privateRanges {
+            // check if this ip is in a private range
+            if inRange(r, ipAddress){
+                return true
+            }
+        }
+    }
+    return false
+}
+
+
+func getIPAdress(r *http.Request) string {
+    for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
+        addresses := strings.Split(r.Header.Get(h), ",")
+        // march from right to left until we get a public address
+        // that will be the address right before our proxy.
+        for i := len(addresses) -1 ; i >= 0; i-- {
+            ip := strings.TrimSpace(addresses[i])
+            // header can contain spaces too, strip those out.
+            realIP := net.ParseIP(ip)
+            if !realIP.IsGlobalUnicast() || isPrivateSubnet(realIP) {
+                // bad address, go to next
+                continue
+            }
+            return ip
+        }
+    }
+    return ""
+}
 
 
 // --------------------------------------------------------------------------------------
@@ -84,12 +164,14 @@ func Hls(ctx *state.State, h http.Handler) http.Handler {
             // generate a new token if the client does not supply one
             if token == "" {
                 token = nextToken()
-
+                
+                actualIP := getIPAdress(r)
+                
                 stream.Lock()
                 stream.Viewers[token] = &state.Viewer{
                     FirstSeen: time.Now(),
                     LastSeen: time.Now(),
-                    Ip: r.RemoteAddr,
+                    Ip: actualIP,
                 }
                 stream.Unlock()
 

--- a/influx.go
+++ b/influx.go
@@ -24,7 +24,7 @@ import (
     "os"
     "time"
 
-    "github.com/influxdata/influxdb/client/v2"
+    "github.com/influxdata/influxdb1-client/v2"
 
     "github.com/faryon93/hlswatch/state"
 )

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,6 +31,8 @@ http {
         listen 80;
 
         location / {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_pass http://localhost:3000;
         }
     }


### PR DESCRIPTION
Fixed on Issue #10 where the Nginx proxy is not passing real IP to hlswatch. 
This is fixed by making Nginx attach the original requester's IP to the X headers. 
hlswatch then read these headers and extract the real IP. 

Fixed on docker build problem #7 